### PR TITLE
Increase L1 size to 2560 for SFNNv8 nets

### DIFF
--- a/model.py
+++ b/model.py
@@ -7,7 +7,7 @@ import copy
 from feature_transformer import DoubleFeatureTransformerSlice
 
 # 3 layer fully connected network
-L1 = 2048
+L1 = 2560
 L2 = 15
 L3 = 32
 


### PR DESCRIPTION
This was used to train a larger master net nn-ac1dbea57aa3.nnue in:
https://github.com/official-stockfish/Stockfish/pull/4795