### PR TITLE
Fix extraneous filename .encode in FenBatchProvider, which was result…

### DIFF
--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -97,7 +97,7 @@ class FenBatchProvider:
         wld_filtered=False,
         param_index=0):
 
-        self.filename = filename.encode('utf-8')
+        self.filename = filename
         self.cyclic = cyclic
         self.num_workers = num_workers
         self.batch_size = batch_size


### PR DESCRIPTION
…ing in double .encode on creation.

Showed as an issue when running FT optimization with a FEN list (.epd)