### PR TITLE
use pdep to find nthSetBitIndex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,28 +27,27 @@ function(check_amd_family_25_or_newer)
         OUTPUT_VARIABLE CPU_FAMILY
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    execute_process(
+        COMMAND grep -o "bmi2" /proc/cpuinfo
+        OUTPUT_VARIABLE CPU_BMI2
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-    if(VENDOR_ID STREQUAL "AuthenticAMD" AND CPU_FAMILY GREATER_EQUAL "25")
-        set(CPU_AMD_FAMILY_25_OR_NEWER TRUE PARENT_SCOPE)
+    if(VENDOR_ID STREQUAL "AuthenticAMD" )
+        if(CPU_FAMILY GREATER_EQUAL "23" AND CPU_BMI2 STREQUAL "bmi2")
+            set(CPU_SUPPORTS_BMI2 TRUE PARENT_SCOPE)
+    elseif(CPU_BMI2 STREQUAL "bmi2")
+        set(CPU_SUPPORTS_BMI2 TRUE PARENT_SCOPE)
     else()
-        set(CPU_AMD_FAMILY_25_OR_NEWER FALSE PARENT_SCOPE)
+        set(CPU_SUPPORTS_BMI2 FALSE PARENT_SCOPE)
     endif()
 endfunction()
 
-# Call the function to check if the CPU is AMD and not older than family 25
 check_amd_family_25_or_newer()
 
-# Check for BMI2 support
-check_cxx_compiler_flag("-mbmi2" COMPILER_SUPPORTS_BMI2)
-if(COMPILER_SUPPORTS_BMI2)
-    if(CPU_AMD_FAMILY_25_OR_NEWER OR NOT VENDOR_ID STREQUAL "AuthenticAMD")
-        message(STATUS "Adding BMI2 support")
-        add_definitions(-DHAS_BMI2)
-    else()
-        message(STATUS "CPU is older than AMD family 25, not adding BMI2 support")
-    endif()
-else()
-    message(FATAL_ERROR "Compiler does not support BMI2")
+if(CPU_SUPPORTS_BMI2)
+    message(STATUS "Adding BMI2 support")
+    add_definitions(-DHAS_BMI2)
 endif()
 
 add_library(training_data_loader SHARED training_data_loader.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(training_data_loader)
+project(training_data_loader CXX)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo)
@@ -12,6 +12,44 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3 -march=native -DNDEBUG")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED 17)
+
+include(CheckCXXCompilerFlag)
+
+# Function to check if the CPU is AMD and not older than family 25
+function(check_amd_family_25_or_newer)
+    execute_process(
+        COMMAND awk "/^vendor_id/{{print \$3; exit}}" /proc/cpuinfo
+        OUTPUT_VARIABLE VENDOR_ID
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND awk "/^cpu family/{{print \$4; exit}}" /proc/cpuinfo
+        OUTPUT_VARIABLE CPU_FAMILY
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(VENDOR_ID STREQUAL "AuthenticAMD" AND CPU_FAMILY GREATER_EQUAL "25")
+        set(CPU_AMD_FAMILY_25_OR_NEWER TRUE PARENT_SCOPE)
+    else()
+        set(CPU_AMD_FAMILY_25_OR_NEWER FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Call the function to check if the CPU is AMD and not older than family 25
+check_amd_family_25_or_newer()
+
+# Check for BMI2 support
+check_cxx_compiler_flag("-mbmi2" COMPILER_SUPPORTS_BMI2)
+if(COMPILER_SUPPORTS_BMI2)
+    if(CPU_AMD_FAMILY_25_OR_NEWER OR NOT VENDOR_ID STREQUAL "AuthenticAMD")
+        message(STATUS "Adding BMI2 support")
+        add_definitions(-DHAS_BMI2)
+    else()
+        message(STATUS "CPU is older than AMD family 25, not adding BMI2 support")
+    endif()
+else()
+    message(FATAL_ERROR "Compiler does not support BMI2")
+endif()
 
 add_library(training_data_loader SHARED training_data_loader.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED 17)
 
 include(CheckCXXCompilerFlag)
 
-# Function to check if the CPU is AMD and not older than family 25
-function(check_amd_family_25_or_newer)
+# Function to check if the CPU supports bmi2
+function(check_bmi2_support)
     execute_process(
         COMMAND awk "/^vendor_id/{{print \$3; exit}}" /proc/cpuinfo
         OUTPUT_VARIABLE VENDOR_ID
@@ -43,7 +43,7 @@ function(check_amd_family_25_or_newer)
     endif()
 endfunction()
 
-check_amd_family_25_or_newer()
+check_bmi2_support()
 
 if(CPU_SUPPORTS_BMI2)
     message(STATUS "Adding BMI2 support")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,24 +18,25 @@ include(CheckCXXCompilerFlag)
 # Function to check if the CPU supports bmi2
 function(check_bmi2_support)
     execute_process(
-        COMMAND awk "/^vendor_id/{{print \$3; exit}}" /proc/cpuinfo
+        COMMAND bash -c "awk '/^vendor_id/{{print \$3; exit}}' /proc/cpuinfo"
         OUTPUT_VARIABLE VENDOR_ID
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
-        COMMAND awk "/^cpu family/{{print \$4; exit}}" /proc/cpuinfo
+        COMMAND bash -c "awk '/^cpu family/{{print \$4; exit}}' /proc/cpuinfo"
         OUTPUT_VARIABLE CPU_FAMILY
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
-        COMMAND grep -o "bmi2" /proc/cpuinfo
+        COMMAND bash -c "grep -m1 -o 'bmi2' /proc/cpuinfo"
         OUTPUT_VARIABLE CPU_BMI2
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    if(VENDOR_ID STREQUAL "AuthenticAMD" )
+    if(VENDOR_ID STREQUAL "AuthenticAMD")
         if(CPU_FAMILY GREATER_EQUAL "23" AND CPU_BMI2 STREQUAL "bmi2")
             set(CPU_SUPPORTS_BMI2 TRUE PARENT_SCOPE)
+        endif()
     elseif(CPU_BMI2 STREQUAL "bmi2")
         set(CPU_SUPPORTS_BMI2 TRUE PARENT_SCOPE)
     else()
@@ -48,6 +49,8 @@ check_bmi2_support()
 if(CPU_SUPPORTS_BMI2)
     message(STATUS "Adding BMI2 support")
     add_definitions(-DHAS_BMI2)
+else()
+    message(STATUS "No BMI2 support")
 endif()
 
 add_library(training_data_loader SHARED training_data_loader.cpp)

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -48,7 +48,7 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <mutex>
 #include <random>
 
-#ifdef __BMI2__
+#ifdef HAS_BMI2
 #include <immintrin.h> // _pdep_u64
 #endif
 
@@ -267,7 +267,7 @@ namespace chess
 
     inline int nthSetBitIndex(std::uint64_t v, std::uint64_t n)
     {
-    #ifdef __BMI2__
+    #ifdef HAS_BMI2
         return intrin::msb(_pdep_u64(1ULL << n, v));
     #endif
 

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -48,6 +48,10 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <mutex>
 #include <random>
 
+#ifdef __BMI2__
+#include <immintrin.h> // _pdep_u64
+#endif
+
 #include "rng.h"
 
 #if (defined(_MSC_VER) || defined(__INTEL_COMPILER)) && !defined(__clang__)
@@ -263,6 +267,10 @@ namespace chess
 
     inline int nthSetBitIndex(std::uint64_t v, std::uint64_t n)
     {
+    #ifdef __BMI2__
+        return intrin::msb(_pdep_u64(1ULL << n, v));
+    #endif
+
         std::uint64_t shift = 0;
 
         std::uint64_t p = intrin::popcount(v & 0xFFFFFFFFull);


### PR DESCRIPTION
a bit better than the current approach, current approach shows up in profile with ~10% overhead
https://godbolt.org/z/avfT1jY3Y

cmake checks for zen3+ cpu