### PR TITLE
Fix Weights Loading Torch

### DIFF
--- a/serialize.py
+++ b/serialize.py
@@ -313,7 +313,7 @@ def main():
     nnue = M.NNUE.load_from_checkpoint(args.source, feature_set=feature_set, map_location=torch.device("cpu"))
     nnue.eval()
   elif args.source.endswith('.pt'):
-    nnue = torch.load(args.source)
+    nnue = torch.load(args.source, weights_only=False)
   elif args.source.endswith('.nnue'):
     with open(args.source, 'rb') as f:
       reader = NNUEReader(f, feature_set)

--- a/train.py
+++ b/train.py
@@ -108,7 +108,7 @@ def main():
       param_index=args.param_index
     )
   else:
-    nnue = torch.load(args.resume_from_model)
+    nnue = torch.load(args.resume_from_model, weights_only=False)
     nnue.set_feature_set(feature_set)
     nnue.start_lambda = start_lambda
     nnue.end_lambda = end_lambda

--- a/visualize.py
+++ b/visualize.py
@@ -455,7 +455,7 @@ class NNUEVisualizer():
 def load_model(filename, feature_set):
     if filename.endswith(".pt") or filename.endswith(".ckpt"):
         if filename.endswith(".pt"):
-            model = torch.load(filename)
+            model = torch.load(filename, weights_only=False)
         else:
             model = M.NNUE.load_from_checkpoint(
                 filename, feature_set=feature_set)

--- a/visualize_multi_hist.py
+++ b/visualize_multi_hist.py
@@ -12,7 +12,7 @@ from serialize import NNUEReader
 def load_model(filename, feature_set):
     if filename.endswith(".pt") or filename.endswith(".ckpt"):
         if filename.endswith(".pt"):
-            model = torch.load(filename)
+            model = torch.load(filename, weights_only=False)
         else:
             model = M.NNUE.load_from_checkpoint(
                 filename, feature_set=feature_set)


### PR DESCRIPTION
In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.