### PR TITLE
Enable cudagraphs compile backend

### DIFF
--- a/model.py
+++ b/model.py
@@ -81,11 +81,8 @@ class LayerStacks(nn.Module):
         self.output.bias = nn.Parameter(output_bias)
 
     def forward(self, x, ls_indices):
-        # Precompute and cache the offset for gathers
-        if self.idx_offset == None or self.idx_offset.shape[0] != x.shape[0]:
-            self.idx_offset = torch.arange(
-                0, x.shape[0] * self.count, self.count, device=ls_indices.device
-            )
+
+        assert self.idx_offset != None and self.idx_offset.shape[0] == x.shape[0]
 
         indices = ls_indices.flatten() + self.idx_offset
 


### PR DESCRIPTION
The cudagraphs backend is a speedups for small nets, slowdown for large ones. Make it a CLI argument.

Benchmarking

big: numactl --cpunodebind=0 --membind=0 python train.py /workspace/data/dfrc_n5000.binpack\
             --threads 4 --num-workers  64 --batch-size 16384 --random-fen-skipping 3\
             --features=HalfKAv2_hm^ --max_epochs=4 --default_root_dir ./training/runs/run_0\
             --gpus="0,"

small: big --l1=128 -compile-backend=cudagraphs

reported after epoch 3 / end of the run.

```
                   big                             small
master         84.99it/s, 84.57it/s          210.57it/s, 214.03it/s
PR             82.56it/s. 85.00it/s          249.80it/s, 252.89it/s
```

using cudagraphs for the big net yields:
               60.27it/s, 59.24it/s