### PR TITLE
fix ftperm from checkpoint

### DIFF
--- a/model/utils/coalesce_weights.py
+++ b/model/utils/coalesce_weights.py
@@ -1,12 +1,16 @@
-from ..model import NNUEModel
+from torch import Tensor
+
+from ..features import FeatureSet
 from ..feature_transformer import BaseFeatureTransformerSlice
 
 
-def coalesce_ft_weights(model: NNUEModel, layer: BaseFeatureTransformerSlice):
+def coalesce_ft_weights(
+    feature_set: FeatureSet, layer: BaseFeatureTransformerSlice
+) -> Tensor:
     weight = layer.weight.data
-    indices = model.feature_set.get_virtual_to_real_features_gather_indices()
+    indices = feature_set.get_virtual_to_real_features_gather_indices()
     weight_coalesced = weight.new_zeros(
-        (model.feature_set.num_real_features, weight.shape[1])
+        (feature_set.num_real_features, weight.shape[1])
     )
     for i_real, is_virtual in enumerate(indices):
         weight_coalesced[i_real, :] = sum(

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -146,7 +146,7 @@ class NNUEWriter:
 
         bias = layer.bias.data[: model.L1]
 
-        all_weight = coalesce_ft_weights(model, layer)
+        all_weight = coalesce_ft_weights(model.feature_set, layer)
         weight = all_weight[:, : model.L1]
         psqt_weight = all_weight[:, model.L1 :]
 

--- a/serialize.py
+++ b/serialize.py
@@ -136,6 +136,11 @@ def main():
             if args.device is not None:
                 ftperm.set_cupy_device(args.device)
 
+        if not args.source.endswith(".nnue"):
+            nnue.model.input.weight.data = M.coalesce_ft_weights(
+                nnue.model.feature_set, nnue.model.input
+            )
+
         ftperm.ft_optimize(
             nnue.model,
             args.ft_optimize_data,

--- a/visualize.py
+++ b/visualize.py
@@ -39,12 +39,14 @@ class NNUEVisualizer:
 
     def plot_input_weights(self):
         # Coalesce weights and transform them to Numpy domain.
-        weights = M.coalesce_ft_weights(self.model, self.model.input)
+        weights = M.coalesce_ft_weights(self.model.feature_set, self.model.input)
         weights = weights[:, : self.model.L1]
         weights = weights.flatten().numpy()
 
         if self.args.ref_model:
-            ref_weights = M.coalesce_ft_weights(self.ref_model, self.ref_model.input)
+            ref_weights = M.coalesce_ft_weights(
+                self.ref_model.feature_set, self.ref_model.input
+            )
             ref_weights = ref_weights[:, : self.model.L1]
             ref_weights = ref_weights.flatten().numpy()
             weights -= ref_weights

--- a/visualize_multi_hist.py
+++ b/visualize_multi_hist.py
@@ -88,7 +88,9 @@ def main():
         for m in args.models
     ]
 
-    coalesced_ins = [M.coalesce_ft_weights(model, model.input) for model in models]
+    coalesced_ins = [
+        M.coalesce_ft_weights(model.feature_set, model.input) for model in models
+    ]
     input_weights = [
         coalesced_in[:, : args.l1].flatten().numpy() for coalesced_in in coalesced_ins
     ]


### PR DESCRIPTION
fixes the weight disparity by coalescing the feature transformer before permutation. this is not done when reading .nnue networks as NNUEReader coalesces the ft automatically upon saving the network to .nnue.

also refactors coalesce_ft_weights to take in the FeatureSet instead of the whole NNUEModel

closes #322